### PR TITLE
[IMP] product_unique_serial: replaced check unicity method …

### DIFF
--- a/product_unique_serial/README.md
+++ b/product_unique_serial/README.md
@@ -1,4 +1,0 @@
-Product Unique Serial Number
-==================
-Add a field to product to activate check if is a product unique serial number.
-Add a check constraint to deny stock moves with quantity different to 1 if has unique serial number as True.

--- a/product_unique_serial/README.rst
+++ b/product_unique_serial/README.rst
@@ -1,0 +1,11 @@
+Product Unique Serial Number
+============================
+
+Turns production lot tracking numbers into unique per product instance code (serial number).
+
+Features
+--------
+- Add a field to product to activate check if is a product unique serial number.
+- Add a constraint to deny stock quants with quantity different to 1 if product as unique serial number as True.
+- Add a constraint to deny stock quants with quantity different to 1 when serial number that exists in another location
+- Add a field to lot to set domain to show only serial number that exists in source location

--- a/product_unique_serial/__openerp__.py
+++ b/product_unique_serial/__openerp__.py
@@ -1,10 +1,11 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
 {
     'name': "Product Serial Unique Number",
-    'author': "vauxoo",
+    'author': "Vauxoo",
     'website': "http://www.vauxoo.com",
     'category': 'stock',
     'version': '1.0',
+    'license': "AGPL-3",
     'depends': ['stock_no_negative'],
     'data': [
         "views/product_view.xml",

--- a/product_unique_serial/model/product.py
+++ b/product_unique_serial/model/product.py
@@ -1,4 +1,24 @@
-# -*- coding: utf-8 -*-
+# coding: utf-8
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    Copyright (C) 2007-2015 (<https://vauxoo.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
 from openerp import fields, models
 
 

--- a/product_unique_serial/tests/test_for_unicity.py
+++ b/product_unique_serial/tests/test_for_unicity.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# coding: utf-8
 ###############################################################################
 #    Module Writen to OpenERP, Open Source Management Solution
 #
@@ -26,8 +26,8 @@
 
 from copy import deepcopy
 
+from openerp import exceptions
 from openerp.tests.common import TransactionCase
-from openerp.exceptions import except_orm
 from openerp.tools import mute_logger
 from psycopg2 import IntegrityError
 
@@ -136,13 +136,13 @@ class TestUnicity(TransactionCase):
         """
         Test 1. Creating 2 pickings with 1 product for the same serial number,
         in the receipts scope, with the next form:
-        - Picking 1
+        - Picking 1 IN
         =============================================
         || Product ||  Quantity  ||  Serial Number ||
         =============================================
         ||    A    ||      1     ||      001       ||
         =============================================
-        - Picking 2
+        - Picking 2 IN
         =============================================
         || Product ||  Quantity  ||  Serial Number ||
         =============================================
@@ -173,10 +173,7 @@ class TestUnicity(TransactionCase):
         self.transfer_picking(
             picking_1,
             self.env.ref('product_unique_serial.serial_number_demo_1'))
-        with self.assertRaisesRegexp(
-                except_orm,
-                r"you will have a quantity of '2.0' "
-                r"in lot '86137801852514'"):
+        with self.assertRaises(exceptions.Warning):
             self.transfer_picking(
                 picking_2,
                 [self.env.ref('product_unique_serial.serial_number_demo_1')])
@@ -185,13 +182,13 @@ class TestUnicity(TransactionCase):
         """
         Test 2. Creating 2 pickings with 1 product for the same serial number,
         in the delivery orders scope, with the next form:
-        - Picking 1
+        - Picking 1 OUT
         =============================================
         || Product ||  Quantity  ||  Serial Number ||
         =============================================
         ||    A    ||      1     ||      001       ||
         =============================================
-        - Picking 2
+        - Picking 2 OUT
         =============================================
         || Product ||  Quantity  ||  Serial Number ||
         =============================================
@@ -234,10 +231,7 @@ class TestUnicity(TransactionCase):
         self.transfer_picking(
             picking_out_1,
             self.env.ref('product_unique_serial.serial_number_demo_1'))
-        with self.assertRaisesRegexp(
-                except_orm,
-                r"you will have a quantity of '-1.0' "
-                r"in lot '86137801852514'"):
+        with self.assertRaises(exceptions.Warning):
             self.transfer_picking(
                 picking_out_2,
                 [self.env.ref('product_unique_serial.serial_number_demo_1')])
@@ -246,7 +240,7 @@ class TestUnicity(TransactionCase):
         """
         Test 3. Creating a picking with 1 product for the same serial number,
         in the delivery orders scope, with the next form:
-        - Picking 1
+        - Picking 1 IN
         =============================================
         || Product ||  Quantity  ||  Serial Number ||
         =============================================
@@ -268,7 +262,7 @@ class TestUnicity(TransactionCase):
             stock_move_datas, picking_data_1,
             self.env.ref('stock.picking_type_in'))
         # Executing the wizard for pickings transfering
-        with self.assertRaisesRegexp(except_orm, r'but has qty > 1'):
+        with self.assertRaises(exceptions.Warning):
             self.transfer_picking(
                 picking_1,
                 [self.env.ref('product_unique_serial.serial_number_demo_2')])
@@ -316,13 +310,13 @@ class TestUnicity(TransactionCase):
         """
         Test 5. Creating 2 pickings with 1 product for the same serial number,
         in the internal scope, with the next form:
-        - Picking 1
+        - Picking 1 INTERNAL
         =============================================
         || Product ||  Quantity  ||  Serial Number ||
         =============================================
         ||    A    ||      1     ||      001       ||
         =============================================
-        - Picking 2
+        - Picking 2 INTERNAL
         =============================================
         || Product ||  Quantity  ||  Serial Number ||
         =============================================
@@ -369,9 +363,7 @@ class TestUnicity(TransactionCase):
         self.transfer_picking(
             picking_internal_1,
             [self.env.ref('product_unique_serial.serial_number_demo_1')])
-        with self.assertRaisesRegexp(
-                except_orm,
-                r"Product 'Nokia 2630' has active 'check no negative'"):
+        with self.assertRaises(exceptions.ValidationError):
             self.transfer_picking(
                 picking_internal_2,
                 [self.env.ref('product_unique_serial.serial_number_demo_1')])
@@ -388,6 +380,5 @@ class TestUnicity(TransactionCase):
             'product_id': product_id.id
         }
         self.stock_production_lot_obj.create(lot_data)
-        with self.assertRaisesRegexp(
-                IntegrityError, r'"stock_production_lot_name_ref_uniq"'):
+        with self.assertRaises(IntegrityError):
             self.stock_production_lot_obj.create(lot_data)

--- a/product_unique_serial/tests/test_for_unicity.py
+++ b/product_unique_serial/tests/test_for_unicity.py
@@ -173,7 +173,10 @@ class TestUnicity(TransactionCase):
         self.transfer_picking(
             picking_1,
             self.env.ref('product_unique_serial.serial_number_demo_1'))
-        with self.assertRaises(exceptions.Warning):
+        with self.assertRaisesRegexp(
+                exceptions.Warning,
+                "The serial number 86137801852514 can only belong to"
+                " a single product in stock"):
             self.transfer_picking(
                 picking_2,
                 [self.env.ref('product_unique_serial.serial_number_demo_1')])
@@ -231,7 +234,10 @@ class TestUnicity(TransactionCase):
         self.transfer_picking(
             picking_out_1,
             self.env.ref('product_unique_serial.serial_number_demo_1'))
-        with self.assertRaises(exceptions.Warning):
+        with self.assertRaisesRegexp(
+                exceptions.Warning,
+                "The serial number 86137801852514 can only belong to"
+                " a single product in stock"):
             self.transfer_picking(
                 picking_out_2,
                 [self.env.ref('product_unique_serial.serial_number_demo_1')])
@@ -262,7 +268,10 @@ class TestUnicity(TransactionCase):
             stock_move_datas, picking_data_1,
             self.env.ref('stock.picking_type_in'))
         # Executing the wizard for pickings transfering
-        with self.assertRaises(exceptions.Warning):
+        with self.assertRaisesRegexp(
+                exceptions.Warning,
+                "You should only receive by the piece with the same serial "
+                "number"):
             self.transfer_picking(
                 picking_1,
                 [self.env.ref('product_unique_serial.serial_number_demo_2')])
@@ -363,7 +372,9 @@ class TestUnicity(TransactionCase):
         self.transfer_picking(
             picking_internal_1,
             [self.env.ref('product_unique_serial.serial_number_demo_1')])
-        with self.assertRaises(exceptions.ValidationError):
+        with self.assertRaisesRegexp(
+                exceptions.ValidationError,
+                "Product 'Nokia 2630' has active 'check no negative'"):
             self.transfer_picking(
                 picking_internal_2,
                 [self.env.ref('product_unique_serial.serial_number_demo_1')])
@@ -371,7 +382,7 @@ class TestUnicity(TransactionCase):
     @mute_logger('openerp.sql_db')
     def test_6_1serialnumber_1product_2records(self):
         """
-        Test 7. Creating 2 identical serial numbers
+        Test 6. Creating 2 identical serial numbers
         """
         product_id = self.env.ref('product_unique_serial.product_demo_1')
         lot_data = {
@@ -380,5 +391,6 @@ class TestUnicity(TransactionCase):
             'product_id': product_id.id
         }
         self.stock_production_lot_obj.create(lot_data)
-        with self.assertRaises(IntegrityError):
+        with self.assertRaisesRegexp(
+                IntegrityError, r'"stock_production_lot_name_ref_uniq"'):
             self.stock_production_lot_obj.create(lot_data)

--- a/product_unique_serial/tests/test_for_unicity.py
+++ b/product_unique_serial/tests/test_for_unicity.py
@@ -50,8 +50,6 @@ class TestUnicity(TransactionCase):
         self.product_uom_obj = self.env['product.uom']
         self.stock_location_obj = self.env['stock.location']
         self.stock_production_lot_obj = self.env['stock.production.lot']
-        self.mrp_production_obj = self.env['mrp.production']
-        self.product_produce_obj = self.env['mrp.product.produce']
 
     def create_stock_picking(self, moves_data, picking_data, picking_type):
         """ Returns the stock.picking object, with his respective created
@@ -184,7 +182,7 @@ class TestUnicity(TransactionCase):
                 picking_2,
                 [self.env.ref('product_unique_serial.serial_number_demo_1')])
 
-    def test_1_2_1product_1serialnumber_2p_in(self):
+    def test_1_2_1product_1serialnumber_2p_track_incoming(self):
         """
         Test 1.2. (track incoming) Creating 2 pickings with 1 product for the
         same serial number, in the receipts scope, with the next form:
@@ -206,11 +204,11 @@ class TestUnicity(TransactionCase):
         """
         # Creating move line for picking
         product = self.env.ref('product_unique_serial.product_demo_1')
-        # track_production and lot_unique_ok to test unicity
+        # track_incoming and lot_unique_ok to test unicity
         self.assertTrue(product.write({'track_all': False,
                                        'track_incoming': True,
                                        'lot_unique_ok': True}),
-                        "Cannot check tracking incoming to product")
+                        "Cannot write product %s" % (product.name))
 
         stock_move_datas = [{
             'product_id': product.id,
@@ -302,7 +300,7 @@ class TestUnicity(TransactionCase):
                 picking_out_2,
                 [self.env.ref('product_unique_serial.serial_number_demo_1')])
 
-    def test_2_2_1product_1serialnumber_2p_out(self):
+    def test_2_2_1product_1serialnumber_2p_track_outgoing(self):
         """
         Test 2.2. (track outgoing) Creating 2 pickings with 1 product for the
         same serial number, in the delivery orders scope, with the next form:
@@ -325,11 +323,11 @@ class TestUnicity(TransactionCase):
         """
         # Creating move line for picking
         product = self.env.ref('product_unique_serial.product_demo_1')
-        # track_production and lot_unique_ok to test unicity
+        # track_outgoing and lot_unique_ok to test unicity
         self.assertTrue(product.write({'track_all': False,
                                        'track_outgoing': True,
                                        'lot_unique_ok': True}),
-                        "Cannot check tracking outgoing to product")
+                        "Cannot write product %s" % (product.name))
 
         stock_move_datas = [{
             'product_id': product.id,
@@ -524,77 +522,94 @@ class TestUnicity(TransactionCase):
                 IntegrityError, r'"stock_production_lot_name_ref_uniq"'):
             self.stock_production_lot_obj.create(lot_data)
 
-    def test_7_1product_1serial_number_production(self):
+    def test_7_1_1product_1serialnumber_track_production_in(self):
         """
-        Test 6. Creating a production order with 1 product as material,
-        2 quantities in different lines with 1 serial number for both
+        Test 7. Creating moves as production order with 1 product
+        as material, 2 moves with 1 qty  and 1 same serial number
+        for both
         """
-        bom = self.env.ref('mrp.mrp_bom_1')
-        sh1 = self.env.ref('product.product_product_17_product_template')
-        sh2 = self.env.ref('product.product_product_18_product_template')
+        product = self.env.ref('product_unique_serial.product_demo_1')
+        # track_production and lot_unique_ok to test unicity
+        self.assertTrue(product.write({'track_all': False,
+                                       # mrp module should be installed
+                                       # to use track_production field
+                                       'track_production': True,
+                                       'lot_unique_ok': True}),
+                        "Cannot write product %s" % (product.name))
         uom = self.env.ref('product.product_uom_unit')
-        stock = self.env.ref('stock.stock_location_stock')
-
-        # Create a Production Order
-        production_order = self.mrp_production_obj.create({
-            'product_id': sh2.id,
-            'bom_id': bom.id,
-            'product_qty': 1.00,
+        location_stock = self.env.ref('stock.stock_location_stock')
+        location_production = self.env.ref('stock.location_production')
+        # create a lot to product
+        lot_vals = {'name': 'AB-092134', 'product_id': product.id}
+        lot_move = self.stock_production_lot_obj.create(lot_vals)
+        # create stock move values
+        stock_move_vals = {
+            'name': '[%s] %s' % (product.default_code, product.name),
+            'product_id': product.id,
+            'product_uom_qty': 1.0,
             'product_uom': uom.id,
-            'location_src_id': stock.id,
-            'location_dest_id': stock.id
-        })
-        # track_production and lot_unique_ok to test unicity in production
-        self.assertTrue(sh1.write({'track_production': True,
-                                   'lot_unique_ok': True}),
-                        "Cannot check tracking production to product")
-        # Check initial state
-        self.assertEqual(production_order.state, 'draft',
-                         'Initial state should be in "draft"')
-        # Change next state and check it
-        production_order.signal_workflow('button_confirm')
-        self.assertEqual(production_order.state, 'confirmed',
-                         "Signal 'confirm' don't work fine!")
-        # Change next state and check it
-        production_order.action_assign()
-        self.assertEqual(production_order.state, 'ready',
-                         "Signal 'ready' don't work fine or product "
-                         "is not available!")
-        # Simulate click on the "Produce" button to run the product
-        # produce wizard.
-        wiz = self.product_produce_obj.with_context({
-            'active_id': production_order.id,
-            'active_ids': [production_order.id],
-            'active_model': 'mrp.production',
-        }).create({'mode': 'consume'})
-
-        consume_lines = wiz.on_change_qty(production_order.product_qty,
-                                          [])['value']['consume_lines']
-        # check if consume_lines has values
-        self.assertTrue(len(consume_lines) > 0,
-                        "Consume lines should have at least one item")
-        lot_vals = {
-            'name': 'AB-092134',
-            'product_id': consume_lines[0][2]['product_id']
+            'product_uos_qty': 1.0,
+            'product_uos': uom.id,
+            'location_id': location_stock.id,
+            'location_dest_id': location_production.id,
+            'restrict_lot_id': lot_move.id
         }
-        lot_line = self.stock_production_lot_obj.create(lot_vals)
-
-        product_qty = consume_lines[0][2]['product_qty']
-        product_id = consume_lines[0][2]['product_id']
-        new_consume_lines = []
-        # split quantities to consume lines
-        for i in range(int(product_qty)):
-            line = [0, False, {'lot_id': lot_line.id,
-                               'product_id': product_id,
-                               'product_qty': 1.0}]
-            new_consume_lines.append(line)
-        # check if new consume_lines has values
-        self.assertTrue(len(new_consume_lines) > 1,
-                        "Consume lines should have more than 1 line")
-        wiz.write({'consume_lines': new_consume_lines})
+        # create first move
+        stock_move_1 = self.stock_move_obj.create(stock_move_vals)
+        stock_move_1.action_confirm()
+        stock_move_1.action_done()
+        # create a second move
+        stock_move_2 = self.stock_move_obj.create(stock_move_vals)
+        stock_move_2.action_confirm()
         # Error raised expected with message expected.
         with self.assertRaisesRegexp(
                 exceptions.Warning,
                 "The serial number %s can only belong to"
                 " a single product in stock" % lot_vals['name']):
-            wiz.do_produce()
+            stock_move_2.action_done()
+
+    def test_7_2_1product_1serialnumber_track_production_out(self):
+        """
+        Test 7.2. Creating moves as finished product, 1 product,
+        2 moves with 1 qty and 1 same serial number for both
+        """
+        product = self.env.ref('product_unique_serial.product_demo_2')
+        # track_incoming, track_prodcution and lot_unique_ok to test unicity
+        self.assertTrue(product.write({'track_all': False,
+                                       'track_incoming': True,
+                                       # mrp module should be installed
+                                       # to use track_production field
+                                       'track_production': True,
+                                       'lot_unique_ok': True}),
+                        "Cannot write product %s" % (product.name))
+        uom = self.env.ref('product.product_uom_unit')
+        location_stock = self.env.ref('stock.stock_location_stock')
+        location_production = self.env.ref('stock.location_production')
+        # create a lot to product
+        lot_vals = {'name': 'bC3i391m9p9200', 'product_id': product.id}
+        lot_move = self.stock_production_lot_obj.create(lot_vals)
+        # create stock move values
+        stock_move_vals = {
+            'name': '[%s] %s' % (product.default_code, product.name),
+            'product_id': product.id,
+            'product_uom_qty': 1.0,
+            'product_uom': uom.id,
+            'product_uos_qty': 1.0,
+            'product_uos': uom.id,
+            'location_id': location_production.id,
+            'location_dest_id': location_stock.id,
+            'restrict_lot_id': lot_move.id
+        }
+        # create first move
+        stock_move_1 = self.stock_move_obj.create(stock_move_vals)
+        stock_move_1.action_confirm()
+        stock_move_1.action_done()
+        # create a second move
+        stock_move_2 = self.stock_move_obj.create(stock_move_vals)
+        stock_move_2.action_confirm()
+        # Error raised expected with message expected.
+        with self.assertRaisesRegexp(
+                exceptions.Warning,
+                "The serial number %s can only belong to"
+                " a single product in stock" % lot_vals['name']):
+            stock_move_2.action_done()

--- a/product_unique_serial/wizard/stock_transfer_details.py
+++ b/product_unique_serial/wizard/stock_transfer_details.py
@@ -1,5 +1,23 @@
-# -*- coding: utf-8 -*-
-
+# coding: utf-8
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    Copyright (C) 2007-2015 (<https://vauxoo.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
 from lxml import etree
 
 from openerp import models, api
@@ -38,18 +56,10 @@ class StockTransferDetails(models.TransientModel):
                 for node in doc.xpath("//field[@name='lot_id']"):
                     if picking.picking_type_id.code != 'incoming':
                         node.set('options', "{'no_create': True}")
-                        # Don't show unused serial.
-                        # allow to select a serial with moves.
-                        # TODO: Disable this option when
-                        #       fields.function last_location_id
-                        #       was fix it
-                        sub_domain = "('quant_ids', '!=', [])"
                         # Set domain to show only serial number
                         # that exists in source location
-                        # TODO: Enable when fields.function
-                        #       last_location_id was fix it
-                        # sub_domain = "('last_location_id', '=', " + \
-                        #     "sourceloc_id)"
+                        sub_domain = "('last_location_id', '=', " + \
+                            "sourceloc_id)"
                     else:
                         # Don't show old serial number
                         # just allow to create new one or


### PR DESCRIPTION
Replaced previous check unicity method by a new one extracted from v9
## Features
- Now validation of 'Unique Lot' is from quants and not from move as was done previously.
- Validate unicity when consume products in manufacturing orders.
- Validate unicity when split a line and each one has same serial number.
- Fixed old TODO to recomputed Last Location in Lot model.
- Standardize and solved some pylint, flake8, pylint-odoo issues
