### PR TITLE
[FIX] Fixing method name on product_unique_serial module

### DIFF
--- a/product_unique_serial/model/stock.py
+++ b/product_unique_serial/model/stock.py
@@ -56,7 +56,7 @@ class StockQuant(models.Model):
 
     @api.multi
     @api.constrains('product_id', 'lot_id', 'qty')
-    def _check_inicity_lot_product(self):
+    def _check_uniqueness_lot_product(self):
         note = _(
             'Remember: When a serial number (lot) is selected, its quantity '
             'is fixed against the quantity in the serial number (lot) and not '


### PR DESCRIPTION
Changing method name from unicity, meaning one, a whole element, to uniqueness, meaning unique, only one of a kind.
