### PR TITLE
[product_unique_serial]: It needs to refresh stock picking view after close product_unique_serial wizard

### DIFF
--- a/product_unique_serial/views/product_view.xml
+++ b/product_unique_serial/views/product_view.xml
@@ -18,3 +18,4 @@
         </record>
     </data>
 </openerp>
+

--- a/product_unique_serial/wizard/stock_serial.py
+++ b/product_unique_serial/wizard/stock_serial.py
@@ -87,7 +87,7 @@ class StockSerial(models.TransientModel):
                     'warning': {
                         'title': _('Warning'),
                         'message': _(
-                            'The Serial number {} already captured'.format(
+                            'The Serial number %s already captured' % (
                                 serial_name.serial.encode('utf-8')))
                     }}
             else:
@@ -127,7 +127,10 @@ class StockSerial(models.TransientModel):
                         restrict_partner_id=[],
                     )
                     quant_obj.quants_reserve(quants, move_id)
-        return True
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'reload',
+        }
 
     @api.model
     def _get_pack_ops_lot(self, move, move_serial):
@@ -185,7 +188,7 @@ class StockSerialLine(models.TransientModel):
                      ('location_id.usage', '=', 'internal')])
                 if other_quants:
                     message = _(
-                        'The serial number {} is already in stock'.format(
+                        'The serial number %s is already in stock' % (
                             serial_number))
                     return {
                         'warning': {
@@ -193,7 +196,7 @@ class StockSerialLine(models.TransientModel):
                             'message': message
                         }}
             if not lot_id:
-                message = _('Serial {} not found'.format(serial_number))
+                message = _('Serial %s not found' % (serial_number))
                 return {
                     'warning': {
                         'title': _('Warning'),


### PR DESCRIPTION
It needs to refresh the stock picking view after close the product_unique_serial wizard, which is necessary so it can see immediately "Transfer" button and prevent the user from having to refresh the view manually to show button.

In video shows current behavior:
https://youtu.be/TqGKwbHG4x0