### PR TITLE
[FIX] product_unique_serial: muted IntegrityError on stock.serial test

### DIFF
--- a/product_unique_serial/tests/test_serial_wizard.py
+++ b/product_unique_serial/tests/test_serial_wizard.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from psycopg2 import IntegrityError
+from openerp.tools import mute_logger
 from .test_common import TestCommon
 
 
@@ -145,6 +146,7 @@ class TestSerialWizard(TestCommon):
             self.assertTrue(
                 serial_line_val.get('warning'), 'warning must be created')
 
+    @mute_logger('openerp.sql_db')
     def test_serial_wizard_uniq_serial_constraint(self):
         """This test validate that number serial is not reapeted
         in wizard"""

--- a/product_unique_serial/views/product_view.xml
+++ b/product_unique_serial/views/product_view.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <openerp>
     <data>
         <record id="view_product_unique_serial_form" model="ir.ui.view">


### PR DESCRIPTION
To fix the following log error:

```
2016-11-21 01:48:11,609 135 INFO openerp_test openerp.modules.module: openerp.addons.product_unique_serial.tests.test_serial_wizard running tests.
2016-11-21 01:48:11,609 135 INFO openerp_test openerp.addons.product_unique_serial.tests.test_serial_wizard: test_serial_wizard_incoming_outgoing (openerp.addons.product_unique_serial.tests.test_serial_wizard.TestSerialWizard)
2016-11-21 01:48:11,609 135 INFO openerp_test openerp.addons.product_unique_serial.tests.test_serial_wizard: ` This test validate the capture of number serial for move of type
2016-11-21 01:48:13,509 135 INFO openerp_test openerp.addons.product_unique_serial.tests.test_serial_wizard: test_serial_wizard_uniq_serial_constraint (openerp.addons.product_unique_serial.tests.test_serial_wizard.TestSerialWizard)
2016-11-21 01:48:13,509 135 INFO openerp_test openerp.addons.product_unique_serial.tests.test_serial_wizard: ` This test validate that number serial is not reapeted
2016-11-21 01:48:13,681 135 ERROR openerp_test openerp.sql_db: bad query: INSERT INTO "stock_serial_line" ("id", "serial", "serial_id", "create_uid", "write_uid", "create_date", "write_date") VALUES(nextval('stock_serial_line_id_seq'), 'serial_1', 4, 1, 1, (now() at time zone 'UTC'), (now() at time zone 'UTC')) RETURNING id
Traceback (most recent call last):
File "/root/odoo-8.0/openerp/sql_db.py", line 234, in execute
res = self._obj.execute(query, params)
IntegrityError: duplicate key value violates unique constraint "stock_serial_line_uniq_serial"
DETAIL:  Key (serial_id, serial)=(4, serial_1) already exists.

2016-11-21 01:48:13,682 135 INFO openerp_test openerp.addons.product_unique_serial.tests.test_serial_wizard: test_serial_wizard_validate_serial_outgoing (openerp.addons.product_unique_serial.tests.test_serial_wizard.TestSerialWizard)
2016-11-21 01:48:13,683 135 INFO openerp_test openerp.addons.product_unique_serial.tests.test_serial_wizard: ` This test validate that number serial
2016-11-21 01:48:13,852 135 INFO openerp_test openerp.addons.product_unique_serial.tests.test_serial_wizard: Ran 3 tests in 2.243s
2016-11-21 01:48:13,853 135 INFO openerp_test openerp.addons.product_unique_serial.tests.test_serial_wizard: OK
```

- Even though the test is OK the runbot will remain in red for this error message
- Also, was fixed some pylint issues