### PR TITLE
[ADD] serial_last_location: New stock_production_lot_last_location module to add last_location_id field in the stock.production.lot model to know the last location of the product related with the serial number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ python:
 
 env:
   global:
-  - LINT_CHECK=0 TESTS="0" VERSION="8.0" ODOO_REPO="vauxoo/odoo"
+  - LINT_CHECK=0 TESTS="0" VERSION="10.0" ODOO_REPO="vauxoo/odoo"
 
   matrix:
   - LINT_CHECK=1

--- a/product_unique_serial/__openerp__.py
+++ b/product_unique_serial/__openerp__.py
@@ -6,15 +6,16 @@
     'category': 'stock',
     'version': '8.0.0.1.0',
     'license': "AGPL-3",
-    'depends': ['stock_no_negative'],
+    'depends': ['stock_no_negative',
+                'serial_last_location',
+                ],
     'data': [
         "views/product_view.xml",
-        "views/stock_view.xml",
         "views/stock_serial_view.xml",
     ],
     'demo': [
         "demo/test_demo.xml",
     ],
-    'installable': True,
+    'installable': False,
     'auto_install': False,
 }

--- a/product_unique_serial/i18n/es.po
+++ b/product_unique_serial/i18n/es.po
@@ -97,11 +97,6 @@ msgid "Is lot unique?"
 msgstr "¿Es lote único?"
 
 #. module: product_unique_serial
-#: field:stock.production.lot,last_location_id:0
-msgid "Last Location"
-msgstr "Última ubicación"
-
-#. module: product_unique_serial
 #: field:stock.serial,__last_update:0
 #: field:stock.serial.line,__last_update:0
 msgid "Last Modified on"

--- a/product_unique_serial/i18n/es_MX.po
+++ b/product_unique_serial/i18n/es_MX.po
@@ -97,11 +97,6 @@ msgid "Is lot unique?"
 msgstr "¿Es lote único?"
 
 #. module: product_unique_serial
-#: field:stock.production.lot,last_location_id:0
-msgid "Last Location"
-msgstr "Última ubicación"
-
-#. module: product_unique_serial
 #: field:stock.serial,__last_update:0
 #: field:stock.serial.line,__last_update:0
 msgid "Last Modified on"

--- a/product_unique_serial/i18n/es_PA.po
+++ b/product_unique_serial/i18n/es_PA.po
@@ -97,11 +97,6 @@ msgid "Is lot unique?"
 msgstr "¿Es lote único?"
 
 #. module: product_unique_serial
-#: field:stock.production.lot,last_location_id:0
-msgid "Last Location"
-msgstr "Última ubicación"
-
-#. module: product_unique_serial
 #: field:stock.serial,__last_update:0
 #: field:stock.serial.line,__last_update:0
 msgid "Last Modified on"

--- a/product_unique_serial/model/stock.py
+++ b/product_unique_serial/model/stock.py
@@ -22,35 +22,6 @@ from openerp import _, api, fields, models
 from openerp.exceptions import ValidationError
 
 
-class StockProductionLot(models.Model):
-    _inherit = 'stock.production.lot'
-
-    @api.multi
-    @api.depends('quant_ids.location_id')
-    def _compute_get_last_location_id(self):
-        for record in self:
-            if record.quant_ids.ids:
-                last_quant_id = max(record.quant_ids.ids)
-                last_quant_data = self.env['stock.quant'].browse(last_quant_id)
-                record.last_location_id = last_quant_data.location_id.id
-            else:
-                record.last_location_id = False
-
-    last_location_id = fields.Many2one(
-        'stock.location',
-        string="Last Location",
-        compute='_compute_get_last_location_id',
-        store=True)
-
-    # Overwrite field to deny create serial number duplicated
-    ref = fields.Char('Internal Reference',
-                      help="Internal reference number"
-                           " in this case it"
-                           " is same of manufacturer's"
-                           " serial number",
-                      related="name", store=True, readonly=True)
-
-
 class StockQuant(models.Model):
     _inherit = 'stock.quant'
 

--- a/serial_last_location/README.rst
+++ b/serial_last_location/README.rst
@@ -1,0 +1,8 @@
+Stock Production Lot Last Location
+==================================
+
+Turns production lot tracking numbers into unique per product instance code (serial number).
+
+Features
+--------
+- Add a field to lot to set domain to show only serial number that exists in last location

--- a/serial_last_location/__init__.py
+++ b/serial_last_location/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import models

--- a/serial_last_location/__manifest__.py
+++ b/serial_last_location/__manifest__.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+{
+    'name': "Stock Production Lot Last Location",
+    'author': "Vauxoo",
+    'website': "http://www.vauxoo.com",
+    'category': 'stock',
+    'version': '10.0.0.1.0',
+    'license': "AGPL-3",
+    'depends': ['stock'],
+    'data': [
+        "views/stock_production_lot.xml",
+    ],
+    'installable': True,
+    'auto_install': False,
+}

--- a/serial_last_location/i18n/es.po
+++ b/serial_last_location/i18n/es.po
@@ -1,0 +1,24 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_unique_serial
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 10.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-07-20 01:19+0000\n"
+"PO-Revision-Date: 2016-07-20 02:05+0000\n"
+"Last-Translator: Humberto Arocha <hbto@vauxoo.com>\n"
+"Language-Team: Spanish <http://example.com/projects/stock-logistic-"
+"workflow/product_unique_serial/es/>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 2.2-dev\n"
+
+#. module: serial_last_location
+#: field:stock.production.lot,last_location_id:0
+msgid "Last Location"
+msgstr "Última ubicación"

--- a/serial_last_location/i18n/es_MX.po
+++ b/serial_last_location/i18n/es_MX.po
@@ -1,0 +1,19 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_unique_serial
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-07-20 01:19+0000\n"
+"PO-Revision-Date: 2016-07-20 02:05+0000\n"
+"Last-Translator: Humberto Arocha <hbto@vauxoo.com>\n"
+"Language-Team: Spanish <http://example.com/projects/stock-logistic-"
+"workflow/product_unique_serial/es/>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 2.2-dev\n"

--- a/serial_last_location/i18n/es_PA.po
+++ b/serial_last_location/i18n/es_PA.po
@@ -1,0 +1,19 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* product_unique_serial
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-07-20 01:19+0000\n"
+"PO-Revision-Date: 2016-07-20 02:05+0000\n"
+"Last-Translator: Humberto Arocha <hbto@vauxoo.com>\n"
+"Language-Team: Spanish <http://example.com/projects/stock-logistic-"
+"workflow/product_unique_serial/es/>\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 2.2-dev\n"

--- a/serial_last_location/models/__init__.py
+++ b/serial_last_location/models/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import stock_production_lot

--- a/serial_last_location/models/stock_production_lot.py
+++ b/serial_last_location/models/stock_production_lot.py
@@ -1,0 +1,39 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2017 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Vauxoo
+############################################################################
+from openerp import api, fields, models
+
+
+class StockProductionLot(models.Model):
+    _inherit = 'stock.production.lot'
+
+    @api.multi
+    @api.depends('quant_ids.location_id')
+    def _compute_get_last_location_id(self):
+        for record in self:
+            if record.quant_ids.ids:
+                last_quant_id = max(record.quant_ids.ids)
+                last_quant_data = self.env['stock.quant'].browse(last_quant_id)
+                record.last_location_id = last_quant_data.location_id.id
+            else:
+                record.last_location_id = False
+
+    last_location_id = fields.Many2one(
+        'stock.location',
+        string="Last Location",
+        compute='_compute_get_last_location_id',
+        store=True)
+
+    # Overwrite field to deny create serial number duplicated
+    ref = fields.Char('Internal Reference',
+                      help="Internal reference number"
+                           " in this case it"
+                           " is same of manufacturer's"
+                           " serial number",
+                      related="name", store=True, readonly=True)

--- a/serial_last_location/tests/__init__.py
+++ b/serial_last_location/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_last_location

--- a/serial_last_location/tests/test_last_location.py
+++ b/serial_last_location/tests/test_last_location.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+############################################################################
+#    Module Writen For Odoo, Open Source Management Solution
+#
+#    Copyright (c) 2016 Vauxoo - http://www.vauxoo.com
+#    All Rights Reserved.
+#    info Vauxoo (info@vauxoo.com)
+#    coded by: Yanina Aular <yanina.aular@vauxoo.com>
+#    planned by: Yanina Aular <yanina.aular@vauxoo.com>
+############################################################################
+
+from openerp.tests.common import TransactionCase
+
+
+class TestLastLocation(TransactionCase):
+
+    def test_last_location(self):
+        picking_obj = self.env['stock.picking']
+        move_obj = self.env["stock.move"]
+        stock_pack_obj = self.env['stock.pack.operation']
+        location_id = self.ref('stock.stock_location_suppliers')
+        location_dest_id = self.ref('stock.stock_location_stock')
+
+        picking_id = picking_obj.create(
+            {
+                'picking_type_id': self.ref('stock.picking_type_in'),
+                "location_id": location_id,
+                "location_dest_id": location_dest_id,
+                })
+
+        product_rec = self.env.ref('product.product_product_4')
+
+        move = move_obj.create({
+            "name": product_rec.name,
+            "product_id": product_rec.id,
+            "product_uom": product_rec.uom_id.id,
+            "product_uom_qty": 1.0,
+            "picking_id": picking_id.id,
+            "location_id": location_id,
+            "location_dest_id": location_dest_id,
+        })
+
+        serial_test = self.env['stock.production.lot'].create({
+            'product_id': product_rec.id,
+            'name': 'Product Serial Test Serial Las Location',
+        })
+
+        picking = move.picking_id
+
+        wizard_id = stock_pack_obj.create({
+            'picking_id': picking.id,
+            'product_qty': move.product_uom_qty,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'location_id': picking.location_id.id,
+            'location_dest_id': picking.location_dest_id.id,
+            'product_id': move.product_id.id,
+            'qty_done': move.product_uom_qty,
+        })
+
+        stock_pack_lot = self.env['stock.pack.operation.lot']
+        stock_pack_lot.create({
+            'operation_id': wizard_id.id,
+            'lot_id': serial_test.id,
+        })
+
+        stock_backorder_confirmation = \
+            self.env["stock.backorder.confirmation"]
+        backorder = stock_backorder_confirmation.create({
+            "pick_id": picking.id,
+        })
+        backorder.process()
+
+        self.assertEquals(serial_test.last_location_id.id, location_dest_id)

--- a/serial_last_location/views/stock_production_lot.xml
+++ b/serial_last_location/views/stock_production_lot.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
+<odoo>
     <data>
 
         <record id="view_production_lot_form_inh_pus" model="ir.ui.view">
@@ -14,4 +14,4 @@
         </record>
 
     </data>
-</openerp>
+</odoo>

--- a/stock_no_negative/__openerp__.py
+++ b/stock_no_negative/__openerp__.py
@@ -45,7 +45,7 @@ This module check that can not move a product with quantity available negative
     "js": [],
     "css": [],
     "qweb": [],
-    "installable": True,
+    "installable": False,
     "auto_install": False
 }
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/stock_picking_invoice_link/__openerp__.py
+++ b/stock_picking_invoice_link/__openerp__.py
@@ -44,5 +44,5 @@ Authors
     ],
     "demo": [],
     'test': [],
-    'installable': True,
+    'installable': False,
 }


### PR DESCRIPTION
# Issue: https://github.com/Vauxoo/stock-logistics-workflow/issues/24
[ADD] serial_last_location: New stock_production_lot_last_location module to add last_location_id field in the stock.production.lot model to know the last location of the product related with the serial number